### PR TITLE
chore: add jsdocs

### DIFF
--- a/src/bugsplat-options.ts
+++ b/src/bugsplat-options.ts
@@ -1,9 +1,27 @@
 import { FormDataParam } from './form-data-param';
 
+/**
+ * Additional parameters that can be passed to `post()`
+ *
+ * If any of `appKey`, `user`, `email`, `description` are set,
+ * the corresponding default values will be overwritten
+ */
 export interface BugSplatOptions {
     additionalFormDataParams?: Array<FormDataParam>;
+    /**
+     * Additional metadata that can be queried via BugSplat's web application
+     */
     appKey?: string;
+    /**
+     * Additional info about your crash that gets reset after every post
+     */
     description?: string;
+    /**
+     * The email of your user
+     */
     email?: string;
+    /**
+     * The name or id of your user
+     */
     user?: string;
 }

--- a/src/bugsplat-options.ts
+++ b/src/bugsplat-options.ts
@@ -7,6 +7,11 @@ import { FormDataParam } from './form-data-param';
  * the corresponding default values will be overwritten
  */
 export interface BugSplatOptions {
+    /**
+     * Define arbitrary fields to be appended to the form data
+     * object to be sent. This is useful to pass any additional
+     * data as string or `blob`.
+     */
     additionalFormDataParams?: Array<FormDataParam>;
     /**
      * Additional metadata that can be queried via BugSplat's web application

--- a/src/bugsplat-response.ts
+++ b/src/bugsplat-response.ts
@@ -7,7 +7,7 @@ export interface BugSplatResponseBody {
      */
     status: 'success' | 'fail';
     /**
-     * Server time when response was sent in seconds since epoch.
+     * Server time in seconds since epoch.
      *
      * Get a Date object with:
      * ```
@@ -15,12 +15,9 @@ export interface BugSplatResponseBody {
      * ```
      */
     current_server_time: number;
-    /**
-     * Message from the server
-     */
     message: string;
     /**
-     * Variable support response url
+     * Support response url
      */
     url?: string;
     /**
@@ -29,43 +26,24 @@ export interface BugSplatResponseBody {
     crash_id: number;
 }
 
-/**
- * Post response from BugSplat that was successful.
- */
-export interface BugSplatSuccessResponse {
+export interface BugSplatResponseType<ErrorType extends Error | null> {
     /**
-     * Contains an error if one occurred. Always null for success response.
+     * Contains an error if one occurred.
      */
-    error: null;
+    error: ErrorType;
     /**
-     * Validated crash response object.
+     * Crash response object. Validated if `error` is null.
      */
-    response: BugSplatResponseBody;
+    response: ErrorType extends Error ? unknown : BugSplatResponseBody;
     /**
-     * The original error posted to BugSplat
+     * The original error posted to BugSplat.
      */
     original: Error | string;
 }
 
-/**
- * Post response where an error has occurred.
- */
-export interface BugSplatErrorResponse {
-    /**
-     * Contains an error if one occurred. Always an error for error response.
-     */
-    error: Error;
-    /**
-     * Crash response object. Unknown type because it may have failed validation.
-     */
-    response: unknown;
-    /**
-     * The original error posted to BugSplat
-     */
-    original: Error | string;
-}
-
-export type BugSplatResponse = BugSplatSuccessResponse | BugSplatErrorResponse;
+export type BugSplatResponse =
+    | BugSplatResponseType<null>
+    | BugSplatResponseType<Error>;
 
 const isObject = (val: unknown): val is object =>
     typeof val === 'object' && val !== null;
@@ -73,6 +51,9 @@ const isString = (val: unknown): val is string => typeof val === 'string';
 const isNumber = (val: unknown): val is number => typeof val === 'number';
 const isUndefined = (val: unknown): val is undefined => val === undefined;
 
+/**
+ * Ensure the response body has the expected properties.
+ */
 export function validateResponseBody(
     response: unknown
 ): response is BugSplatResponseBody {

--- a/src/bugsplat-response.ts
+++ b/src/bugsplat-response.ts
@@ -34,7 +34,7 @@ export interface BugSplatResponseType<ErrorType extends Error | null> {
     /**
      * Crash response object. Validated if `error` is null.
      */
-    response: ErrorType extends Error ? unknown : BugSplatResponseBody;
+    response: ErrorType extends null ? BugSplatResponseBody : unknown;
     /**
      * The original error posted to BugSplat.
      */

--- a/src/bugsplat-response.ts
+++ b/src/bugsplat-response.ts
@@ -1,20 +1,67 @@
+/**
+ * Parsed response from BugSplat crash post API.
+ */
 export interface BugSplatResponseBody {
+    /**
+     * Indicates if the post was successful
+     */
     status: 'success' | 'fail';
+    /**
+     * Server time when response was sent in seconds since epoch.
+     *
+     * Get a Date object with:
+     * ```
+     * new Date(response.current_server_time * 1000)
+     * ```
+     */
     current_server_time: number;
+    /**
+     * Message from the server
+     */
     message: string;
+    /**
+     * Variable support response url
+     */
     url?: string;
+    /**
+     * Id of the newly created crash report
+     */
     crash_id: number;
 }
 
+/**
+ * Post response from BugSplat that was successful.
+ */
 export interface BugSplatSuccessResponse {
+    /**
+     * Contains an error if one occurred. Always null for success response.
+     */
     error: null;
+    /**
+     * Validated crash response object.
+     */
     response: BugSplatResponseBody;
+    /**
+     * The original error posted to BugSplat
+     */
     original: Error | string;
 }
 
+/**
+ * Post response where an error has occurred.
+ */
 export interface BugSplatErrorResponse {
+    /**
+     * Contains an error if one occurred. Always an error for error response.
+     */
     error: Error;
+    /**
+     * Crash response object. Unknown type because it may have failed validation.
+     */
     response: unknown;
+    /**
+     * The original error posted to BugSplat
+     */
     original: Error | string;
 }
 

--- a/src/bugsplat-response.ts
+++ b/src/bugsplat-response.ts
@@ -2,7 +2,7 @@ export interface BugSplatResponseBody {
     status: 'success' | 'fail';
     current_server_time: number;
     message: string;
-    url: string;
+    url?: string;
     crash_id: number;
 }
 
@@ -20,16 +20,19 @@ export interface BugSplatErrorResponse {
 
 export type BugSplatResponse = BugSplatSuccessResponse | BugSplatErrorResponse;
 
+const isObject = (val: any): val is object =>
+    typeof val === 'object' && val !== null;
+
 export function validateResponseBody(
     response: unknown
 ): response is BugSplatResponseBody {
     return (
-        typeof response === 'object' &&
-        response !== null &&
+        isObject(response) &&
         (response['status'] === 'success' || response['status'] === 'fail') &&
         typeof response['current_server_time'] === 'number' &&
         typeof response['message'] === 'string' &&
-        typeof response['url'] === 'string' &&
+        (typeof response['url'] === 'string' ||
+            response['url'] === undefined) &&
         typeof response['crash_id'] === 'number'
     );
 }

--- a/src/bugsplat.ts
+++ b/src/bugsplat.ts
@@ -169,7 +169,7 @@ export class BugSplat {
 
     private _createReturnValue<ErrorType extends Error | null>(
         error: ErrorType,
-        response: ErrorType extends Error ? unknown : BugSplatResponseBody,
+        response: ErrorType extends null ? BugSplatResponseBody : unknown,
         original: Error | string
     ): BugSplatResponseType<ErrorType> {
         return {

--- a/src/bugsplat.ts
+++ b/src/bugsplat.ts
@@ -8,7 +8,7 @@ import {
     type BugSplatSuccessResponse,
     validateResponseBody,
 } from './bugsplat-response';
-import { isFormDataStringParam } from './form-data-param';
+import { isFormDataParamString } from './form-data-param';
 
 export function createStandardizedCallStack(error: Error): string {
     if (!error.stack?.includes('Error:')) {
@@ -87,7 +87,7 @@ export class BugSplat {
         body.append('description', description);
         body.append('callstack', callstack);
         additionalFormDataParams.forEach((param) => {
-            if (isFormDataStringParam(param)) {
+            if (isFormDataParamString(param)) {
                 body.append(param.key, param.value);
             } else {
                 body.append(param.key, param.value, param.filename);

--- a/src/bugsplat.ts
+++ b/src/bugsplat.ts
@@ -2,10 +2,9 @@ import fetchPonyfill from 'fetch-ponyfill';
 import FormData from 'form-data';
 import type { BugSplatOptions } from './bugsplat-options';
 import {
-    type BugSplatErrorResponse,
     type BugSplatResponse,
     type BugSplatResponseBody,
-    type BugSplatSuccessResponse,
+    type BugSplatResponseType,
     validateResponseBody,
 } from './bugsplat-response';
 import { isFormDataParamString } from './form-data-param';
@@ -35,8 +34,8 @@ export async function tryParseResponseJson(response: {
 }
 
 /**
- * BugSplat crash posting client. Holds some application data and
- * facilitates sending crash reports through the `post()` method
+ * BugSplat crash posting client. Facilitates sending
+ * crash reports through the `post()` method.
  */
 export class BugSplat {
     private _fetch = fetchPonyfill().fetch;
@@ -168,21 +167,11 @@ export class BugSplat {
         this._user = user;
     }
 
-    private _createReturnValue(
-        error: null,
-        response: BugSplatResponseBody,
+    private _createReturnValue<ErrorType extends Error | null>(
+        error: ErrorType,
+        response: ErrorType extends Error ? unknown : BugSplatResponseBody,
         original: Error | string
-    ): BugSplatSuccessResponse;
-    private _createReturnValue(
-        error: Error,
-        response: unknown,
-        original: Error | string
-    ): BugSplatErrorResponse;
-    private _createReturnValue(
-        error: Error | null,
-        response: BugSplatResponseBody,
-        original: Error | string
-    ): BugSplatResponse {
+    ): BugSplatResponseType<ErrorType> {
         return {
             error,
             response,

--- a/src/bugsplat.ts
+++ b/src/bugsplat.ts
@@ -1,13 +1,13 @@
 import fetchPonyfill from 'fetch-ponyfill';
-import { BugSplatOptions } from './bugsplat-options';
+import FormData from 'form-data';
+import type { BugSplatOptions } from './bugsplat-options';
 import {
-    BugSplatErrorResponse,
-    BugSplatResponse,
-    BugSplatResponseBody,
-    BugSplatSuccessResponse,
+    type BugSplatErrorResponse,
+    type BugSplatResponse,
+    type BugSplatResponseBody,
+    type BugSplatSuccessResponse,
     validateResponseBody,
 } from './bugsplat-response';
-import FormData from 'form-data';
 import { isFormDataStringParam } from './form-data-param';
 
 export function createStandardizedCallStack(error: Error): string {
@@ -18,6 +18,10 @@ export function createStandardizedCallStack(error: Error): string {
     return error.stack;
 }
 
+/**
+ * Attempt to parse a response body as json
+ * @returns parsed body or an empty object if an error occurred while parsing
+ */
 export async function tryParseResponseJson(response: {
     json(): Promise<unknown>;
 }): Promise<unknown> {
@@ -30,6 +34,10 @@ export async function tryParseResponseJson(response: {
     return parsed;
 }
 
+/**
+ * BugSplat crash posting client. Holds some application data and
+ * facilitates sending crash reports through the `post()` method
+ */
 export class BugSplat {
     private _fetch = fetchPonyfill().fetch;
     private _formData = () => new FormData();
@@ -45,6 +53,11 @@ export class BugSplat {
         public readonly version: string
     ) {}
 
+    /**
+     * Posts an arbitrary Error object to BugSplat
+     * @param errorToPost - Error object or a message to be sent to BugSplat
+     * @param options - Additional parameters that can be sent to BugSplat
+     */
     async post(
         errorToPost: Error | string,
         options?: BugSplatOptions
@@ -57,7 +70,7 @@ export class BugSplat {
         const description = options.description || this._description;
         const additionalFormDataParams = options.additionalFormDataParams || [];
         const callstack = createStandardizedCallStack(
-            (<Error>errorToPost)?.stack
+            (errorToPost as Error)?.stack
                 ? <Error>errorToPost
                 : new Error(<string>errorToPost)
         );
@@ -127,18 +140,30 @@ export class BugSplat {
         return this._createReturnValue(null, json, errorToPost);
     }
 
+    /**
+     * Additional metadata that can be queried via BugSplat's web application
+     */
     setDefaultAppKey(appKey: string): void {
         this._appKey = appKey;
     }
 
+    /**
+     * Additional info about your crash that gets reset after every post
+     */
     setDefaultDescription(description: string): void {
         this._description = description;
     }
 
+    /**
+     * The email of your user
+     */
     setDefaultEmail(email: string): void {
         this._email = email;
     }
 
+    /**
+     * The name or id of your user
+     */
     setDefaultUser(user: string): void {
         this._user = user;
     }

--- a/src/bugsplat.ts
+++ b/src/bugsplat.ts
@@ -33,6 +33,8 @@ export async function tryParseResponseJson(response: {
     return parsed;
 }
 
+const isError = (val: unknown): val is Error => Boolean((val as Error)?.stack);
+
 /**
  * BugSplat crash posting client. Facilitates sending
  * crash reports through the `post()` method.
@@ -69,9 +71,7 @@ export class BugSplat {
         const description = options.description || this._description;
         const additionalFormDataParams = options.additionalFormDataParams || [];
         const callstack = createStandardizedCallStack(
-            (errorToPost as Error)?.stack
-                ? <Error>errorToPost
-                : new Error(<string>errorToPost)
+            isError(errorToPost) ? errorToPost : new Error(errorToPost)
         );
 
         const url = 'https://' + this.database + '.bugsplat.com/post/js/';

--- a/src/form-data-param.ts
+++ b/src/form-data-param.ts
@@ -1,43 +1,30 @@
-/**
- * FormDataParam with a string value.
- */
-interface FormDataStringParam {
+interface FormDataParamType<T extends string | Blob> {
     /**
-     * Field key to store the value under
+     * The name of the field whose data is contained in `value`.
      */
     key: string;
     /**
-     * Field `string` value
+     * The field's value.
      */
-    value: string;
+    value: T;
+    /**
+     * The filename reported to the server
+     * when `value` is a `Blob` or `File`
+     */
+    filename?: T extends string ? never : string;
 }
 
 /**
- * FormDataParam with a Blob value
+ * Simple object that is used to construct `FormData` objects.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/FormData/append
  */
-interface FormDataBlobParam {
-    /**
-     * Field key to store the value under
-     */
-    key: string;
-    /**
-     * Field `Blob` or `File` value.
-     */
-    value: Blob;
-    filename?: string;
-}
+export type FormDataParam = FormDataParamType<string> | FormDataParamType<Blob>;
 
 /**
- * Parameter used to construct a FormData object that will be sent to BugSplat.
- * It can have either a string or Blob value.
+ * Check if FormField has a string value
  */
-export type FormDataParam = FormDataStringParam | FormDataBlobParam;
-
-/**
- * Type guard to differentiate FormDataParam sub-type
- */
-export function isFormDataStringParam(
+export function isFormDataParamString(
     param: FormDataParam
-): param is FormDataStringParam {
+): param is FormDataParamType<string> {
     return typeof param.value === 'string';
 }

--- a/src/form-data-param.ts
+++ b/src/form-data-param.ts
@@ -1,16 +1,41 @@
+/**
+ * FormDataParam with a string value.
+ */
 interface FormDataStringParam {
+    /**
+     * Field key to store the value under
+     */
     key: string;
+    /**
+     * Field `string` value
+     */
     value: string;
 }
 
+/**
+ * FormDataParam with a Blob value
+ */
 interface FormDataBlobParam {
+    /**
+     * Field key to store the value under
+     */
     key: string;
+    /**
+     * Field `Blob` or `File` value.
+     */
     value: Blob;
     filename?: string;
 }
 
+/**
+ * Parameter used to construct a FormData object that will be sent to BugSplat.
+ * It can have either a string or Blob value.
+ */
 export type FormDataParam = FormDataStringParam | FormDataBlobParam;
 
+/**
+ * Type guard to differentiate FormDataParam sub-type
+ */
 export function isFormDataStringParam(
     param: FormDataParam
 ): param is FormDataStringParam {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { BugSplat } from './bugsplat';
-export { BugSplatOptions } from './bugsplat-options';
-export { BugSplatResponse } from './bugsplat-response';
-export { FormDataParam } from './form-data-param';
+export type { BugSplatOptions } from './bugsplat-options';
+export type { BugSplatResponse } from './bugsplat-response';
+export type { FormDataParam } from './form-data-param';


### PR DESCRIPTION
I added JSDoc comments for just about everything that is exported and even some internal things too. I also cleaned up a couple types and definitions using generics. That allowed me to define JSDoc comments for a property once instead of having them on multiple interfaces for the same properties.

Fixes #56 

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
