### PR TITLE
feat: add injectable _fetch for React Native compatibility

### DIFF
--- a/spec/bugsplat.spec.ts
+++ b/spec/bugsplat.spec.ts
@@ -107,12 +107,22 @@ describe('BugSplat', function () {
     describe('post', () => {
         it('should use injectable _fetch instead of globalThis.fetch', async () => {
             const customFetch = vi.fn().mockResolvedValue(fakeSuccessResponseBody);
+            const globalFetchSpy = vi.fn().mockResolvedValue(fakeSuccessResponseBody);
+            vi.stubGlobal('fetch', globalFetchSpy);
             // @ts-expect-error -- accessing private field for test
             bugsplat._fetch = customFetch;
 
             await bugsplat.post(new Error('BugSplat!'));
 
             expect(customFetch).toHaveBeenCalledOnce();
+            expect(customFetch).toHaveBeenCalledWith(
+                `https://${database}.bugsplat.com/post/js/`,
+                expect.objectContaining({
+                    method: 'POST',
+                    body: fakeFormData,
+                })
+            );
+            expect(globalFetchSpy).not.toHaveBeenCalled();
         });
 
         it('should call fetch url containing database', async () => {

--- a/spec/bugsplat.spec.ts
+++ b/spec/bugsplat.spec.ts
@@ -99,10 +99,22 @@ describe('BugSplat', function () {
         bugsplat = new BugSplat(database, appName, appVersion);
         // @ts-expect-error -- accessing private field for test mocking
         bugsplat._formData = () => fakeFormData;
-        fetchSpy = vi.spyOn(globalThis, 'fetch') as unknown as Mock;
+        fetchSpy = vi.fn();
+        // @ts-expect-error -- accessing private field for test mocking
+        bugsplat._fetch = fetchSpy;
     });
 
     describe('post', () => {
+        it('should use injectable _fetch instead of globalThis.fetch', async () => {
+            const customFetch = vi.fn().mockResolvedValue(fakeSuccessResponseBody);
+            // @ts-expect-error -- accessing private field for test
+            bugsplat._fetch = customFetch;
+
+            await bugsplat.post(new Error('BugSplat!'));
+
+            expect(customFetch).toHaveBeenCalledOnce();
+        });
+
         it('should call fetch url containing database', async () => {
             fetchSpy.mockResolvedValue(fakeSuccessResponseBody);
 

--- a/src/bugsplat.ts
+++ b/src/bugsplat.ts
@@ -76,6 +76,7 @@ export function appendAttachment(body: FormData, attachment: BugSplatAttachment)
  */
 export class BugSplat {
     private _formData = () => new FormData();
+    private _fetch: typeof globalThis.fetch = globalThis.fetch.bind(globalThis);
 
     private _appKey = '';
     private _attributes: Record<string, string> = {};
@@ -129,7 +130,7 @@ export class BugSplat {
         console.log('BugSplat Error:', errorToPost);
         console.log('BugSplat Url:', url);
 
-        const response = await globalThis.fetch(url, { method: 'POST', body });
+        const response = await this._fetch(url, { method: 'POST', body });
         const json = await tryParseResponseJson(response);
 
         console.log('BugSplat POST status code:', response.status);
@@ -208,7 +209,7 @@ export class BugSplat {
 
         console.log('BugSplat Feedback:', title);
 
-        const response = await globalThis.fetch(baseUrl, { method: 'POST', body });
+        const response = await this._fetch(baseUrl, { method: 'POST', body });
         const json = await tryParseResponseJson(response);
 
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- Adds a private `_fetch` property (same pattern as existing `_formData`) defaulting to `globalThis.fetch`
- `post()` and `postFeedback()` now use `this._fetch` instead of `globalThis.fetch`
- Allows callers like `@bugsplat/expo` to inject `expo/fetch`, which properly serializes JS `Blob` objects in `FormData` — React Native's built-in `globalThis.fetch` silently drops them

## Test plan
- [x] All existing tests pass
- [x] New test verifies the injectable `_fetch` is called instead of `globalThis.fetch`
- [x] Verified end-to-end on iOS: injecting `expo/fetch` makes `componentStack.txt` Blob attachments appear in BugSplat reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)